### PR TITLE
CodeQL: Useless regular-expression character escape

### DIFF
--- a/lib/readfiles.js
+++ b/lib/readfiles.js
@@ -18,7 +18,7 @@ function buildFilter(filters) {
           return '[^\\/]*';
        })
        .replace(/\?/g, '[^\\/]?')
-       .replace(/\*\*/g, '\.*')
+       .replace(/\*\*/g, '.*')
        .replace(/([\-\+\|])/g, '\\$1')
       );
   }


### PR DESCRIPTION
Fix Code scanning alert:
- Title: `Useless regular-expression character escape`
- File: `lib/readfiles.js:21`
- Description:
  ```
  The escape sequence '\.' is equivalent to just '.', so the sequence may still represent a meta-character when it is used in a regular expression.
  ```
- Tool: `CodeQL`
- Rule ID: `js/useless-regexp-character-escape`

(see also #8 and #9)